### PR TITLE
Set LanguageClient revealOutputChannelOn to Never

### DIFF
--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
+import { LanguageClient, RevealOutputChannelOn } from 'vscode-languageclient/node';
 
 import * as plz from './please';
 
@@ -31,6 +31,7 @@ export function startLanguageClient(): vscode.Disposable {
       synchronize: {
         fileEvents: vscode.workspace.createFileSystemWatcher('BUILD*'),
       },
+      revealOutputChannelOn: RevealOutputChannelOn.Never,
     }
   );
   return client.start();


### PR DESCRIPTION
The language server output panel gets revealed everytime something errors. So if you have `"editor.formatOnSave": true` set, and save a file which has (what the formatter deems to be) errors, the panel pops up and gets in the way which is a bit annoying since the errors are already highlighted. Also, `plz format` can't handle valid type hints, so any files with these cause the panel to keep popping up.

What do you think about never revealing the output panel on language server errors? You can still open the output panel on your own if you really want to