### PR TITLE
Don't make the notification for installing Go Outline too intrusive

### DIFF
--- a/src/goDebugCodeLens.ts
+++ b/src/goDebugCodeLens.ts
@@ -5,19 +5,22 @@ import { documentSymbols, getGoOutlineBinPath } from './goOutline';
 const TEST_FUNCTION_REGEX = /^Test\P{Ll}.*/u;
 const TEST_METHOD_REGEX = /^\(([^)]+)\)\.(Test\P{Ll}.*)$/u;
 
+export function checkGoDebugCodeLensSupport(): boolean {
+  if (!getGoOutlineBinPath()) {
+    vscode.window.showErrorMessage(
+      'Go Outline is required for providing code lenses in Go tests for debugging. Install it from https://github.com/ramya-rao-a/go-outline.'
+    );
+    return false;
+  }
+  return true;
+}
+
 export class GoDebugCodeLensProvider implements vscode.CodeLensProvider {
   public async provideCodeLenses(
     document: vscode.TextDocument,
     token: vscode.CancellationToken
   ): Promise<vscode.CodeLens[]> {
     if (!document.fileName.endsWith('_test.go')) {
-      return [];
-    }
-
-    if (!getGoOutlineBinPath()) {
-      vscode.window.showErrorMessage(
-        'Cannot find Go Outline. Install it from https://github.com/ramya-rao-a/go-outline.'
-      );
       return [];
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode';
 
-import { GoDebugCodeLensProvider } from './goDebugCodeLens';
+import {
+  checkGoDebugCodeLensSupport,
+  GoDebugCodeLensProvider,
+} from './goDebugCodeLens';
 import { GoDebugConfigurationProvider } from './goDebugConfiguration';
 import { startLanguageClient } from './languageClient';
 import * as plz from './please';
@@ -26,44 +29,6 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
   context.subscriptions.push(
-    vscode.languages.registerCodeLensProvider(
-      { language: 'go', scheme: 'file' },
-      new GoDebugCodeLensProvider()
-    )
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('plz-go.debug.package', async (args) => {
-      if (vscode.debug.activeDebugSession) {
-        vscode.window.showErrorMessage(
-          'Debug session has already been initialised'
-        );
-        return undefined;
-      }
-      await debug(args.document);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand('plz-go.debug.test', async (args) => {
-      if (vscode.debug.activeDebugSession) {
-        vscode.window.showErrorMessage(
-          'Debug session has already been initialised'
-        );
-        return undefined;
-      }
-      await debug(args.document, args.functionName);
-    })
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      'plz-go.debug.pickTestTarget',
-      async (args): Promise<string> => {
-        return await vscode.window.showQuickPick(args.targets, {
-          placeHolder: 'Select the target associated with this test',
-        });
-      }
-    )
-  );
-  context.subscriptions.push(
     vscode.commands.registerCommand(
       'plz-go.debug.enterTestTarget',
       async (): Promise<string> => {
@@ -83,4 +48,46 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   );
+
+  // Go code lenses
+  if (checkGoDebugCodeLensSupport()) {
+    context.subscriptions.push(
+      vscode.languages.registerCodeLensProvider(
+        { language: 'go', scheme: 'file' },
+        new GoDebugCodeLensProvider()
+      )
+    );
+    context.subscriptions.push(
+      vscode.commands.registerCommand('plz-go.debug.package', async (args) => {
+        if (vscode.debug.activeDebugSession) {
+          vscode.window.showErrorMessage(
+            'Debug session has already been initialised'
+          );
+          return undefined;
+        }
+        await debug(args.document);
+      })
+    );
+    context.subscriptions.push(
+      vscode.commands.registerCommand('plz-go.debug.test', async (args) => {
+        if (vscode.debug.activeDebugSession) {
+          vscode.window.showErrorMessage(
+            'Debug session has already been initialised'
+          );
+          return undefined;
+        }
+        await debug(args.document, args.functionName);
+      })
+    );
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        'plz-go.debug.pickTestTarget',
+        async (args): Promise<string> => {
+          return await vscode.window.showQuickPick(args.targets, {
+            placeHolder: 'Select the target associated with this test',
+          });
+        }
+      )
+    );
+  }
 }


### PR DESCRIPTION
This prevents the "`go-outline` missing requirement" notification from appearing more than once.