### PR TITLE
GOPATH and go.gopath support added

### DIFF
--- a/src/goDebugCodeLens.ts
+++ b/src/goDebugCodeLens.ts
@@ -7,7 +7,7 @@ const TEST_METHOD_REGEX = /^\(([^)]+)\)\.(Test\P{Ll}.*)$/u;
 
 export function checkGoDebugCodeLensSupport(): boolean {
   if (!getGoOutlineBinPath()) {
-    vscode.window.showErrorMessage(
+    vscode.window.showWarningMessage(
       'Go Outline is required for providing code lenses in Go tests for debugging. Install it from https://github.com/ramya-rao-a/go-outline.'
     );
     return false;

--- a/src/goDebugConfiguration.ts
+++ b/src/goDebugConfiguration.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { getBinPath } from './utils/pathUtils';
+import { getBinPathUsingConfig } from './utils';
 import * as plz from './please';
 
 export const PLZ_DEBUG_MIN_VERSION = '16.1.0-beta.4';
@@ -50,7 +50,7 @@ export class GoDebugConfigurationProvider
 
       debugConfiguration['plzBinPath'] = plz.binPath();
 
-      const dlvBinPath = getBinPath('dlv');
+      const dlvBinPath = getBinPathUsingConfig('dlv');
       if (!dlvBinPath) {
         throw new Error(
           'Cannot find Delve debugger. Install it from https://github.com/go-delve/delve.'

--- a/src/goOutline/index.ts
+++ b/src/goOutline/index.ts
@@ -6,7 +6,7 @@
 import { ChildProcess, execFile } from 'child_process';
 import * as vscode from 'vscode';
 
-import { getBinPath } from '../utils/pathUtils';
+import { getBinPathUsingConfig } from '../utils';
 import { NearestNeighborDict, Node } from './avlTree';
 
 // Keep in sync with https://github.com/ramya-rao-a/go-outline
@@ -125,7 +125,7 @@ export function runGoOutline(
 }
 
 export function getGoOutlineBinPath(): string | undefined {
-  return getBinPath('go-outline');
+  return getBinPathUsingConfig('go-outline');
 }
 
 const goKindToCodeKind: { [key: string]: vscode.SymbolKind } = {

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -1,5 +1,8 @@
 import * as vscode from 'vscode';
-import { LanguageClient, RevealOutputChannelOn } from 'vscode-languageclient/node';
+import {
+  LanguageClient,
+  RevealOutputChannelOn,
+} from 'vscode-languageclient/node';
 
 import * as plz from './please';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+import { getBinPath } from './utils/pathUtils';
+
+export function getBinPathUsingConfig(toolName: string): string | undefined {
+  const config = vscode.workspace.getConfiguration();
+  const goPath = config.get<string>('go.gopath');
+
+  return getBinPath(
+    toolName,
+    goPath ? [goPath, process.env['GOPATH']] : undefined
+  );
+}


### PR DESCRIPTION
When trying to locate binaries (such as `go-outline`), the `GOPATH` wasn't being made available to the runtime. This PR fixes that and honours the `go.gopath` setting (from `vscode-go`) that allows it to be overridden.