### PR TITLE
Fix debugging non-suite tests

### DIFF
--- a/src/debugAdapters/goDebugAdapter.ts
+++ b/src/debugAdapters/goDebugAdapter.ts
@@ -404,9 +404,9 @@ export class Delve {
         '--share_network',
         target,
         '--',
-        `TESTS=${launchArgs.test ? '/' + launchArgs.test : ''} ${
-          launchArgs.dlvBinPath
-        } ${dlvArgs.join(' ')}`,
+        `TESTS=${launchArgs.test ?? ''} ${launchArgs.dlvBinPath} ${dlvArgs.join(
+          ' '
+        )}`,
       ];
 
       log(`Running: ${launchArgs.plzBinPath} ${plzArgs.join(' ')}`);

--- a/src/goDebugCodeLens.ts
+++ b/src/goDebugCodeLens.ts
@@ -74,7 +74,7 @@ function extractTestName(symbolName: string): string {
     return symbolName;
   } else if (TEST_METHOD_REGEX.test(symbolName)) {
     const match = symbolName.match(TEST_METHOD_REGEX);
-    return match[2];
+    return `/${match[2]}`;
   }
 
   return '';


### PR DESCRIPTION
When debugging specific tests (instead of the whole package) a `/` character was always being prepended to the name of the method. For instance, to target `TestDBTestSuite/TestSomethingMethod`, `/TestSomethingMethod` was being passed to the test run. This however breaks for non-suite tests where targeting `TestNonSuiteMethod` won't work with `/TestNonSuiteMethod`.

This PR only prepends `/` to test suite methods. Ideally, we would provide the full path but `go-outline` doesn't provide enough symbol information to achieve this.