### PR TITLE
Don't throw for syntax errors while placing codelenses. Read in-memor…

### DIFF
--- a/scripts/rule_calls.py
+++ b/scripts/rule_calls.py
@@ -3,16 +3,13 @@ import json
 import sys
 
 
-def get_rule_calls(build_filename):
+def get_rule_calls(build_file_contents):
     """
     Returns a list of top-level rule calls.
     ie. [{'id': 'python_test', 'name': 'calc_test', 'line': 1}, ...]
     """
 
-    with open(build_filename) as f:
-        read_data = f.read()
-
-    module_ast = ast.parse(read_data)
+    module_ast = ast.parse(build_file_contents)
 
     calls = []
     for stmt in module_ast.body:
@@ -28,9 +25,9 @@ def get_rule_calls(build_filename):
     return calls
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print("Error: A BUILD filename is required.")
-        sys.exit(1)
+    build_file_contents = ''
+    for line in sys.stdin:
+        build_file_contents += line
 
-    rule_calls = get_rule_calls(sys.argv[1])
+    rule_calls = get_rule_calls(build_file_contents)
     print(json.dumps(rule_calls))

--- a/scripts/test_functions.py
+++ b/scripts/test_functions.py
@@ -3,16 +3,13 @@ import json
 import sys
 
 
-def get_test_functions(filename):
+def get_test_functions(source_file_contents):
     """
     Returns a list of test functions.
     ie. [{'id': 'test_empty_array', 'line': 1}, ...]
     """
 
-    with open(filename) as f:
-        read_data = f.read()
-
-    module_ast = ast.parse(read_data)
+    module_ast = ast.parse(source_file_contents)
 
     funcs = []
     for stmt in module_ast.body:
@@ -29,9 +26,9 @@ def get_test_functions(filename):
     return funcs
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2:
-        print("Error: A file is required.")
-        sys.exit(1)
+    source_file_contents = ''
+    for line in sys.stdin:
+        source_file_contents += line
 
-    test_functions = get_test_functions(sys.argv[1])
+    test_functions = get_test_functions(source_file_contents)
     print(json.dumps(test_functions))


### PR DESCRIPTION
…y contents instead of filesystem contents to avoid stale data.