### PR TITLE
Display target on a ssh connection

### DIFF
--- a/src/commands/clipboardWriteCommand.ts
+++ b/src/commands/clipboardWriteCommand.ts
@@ -5,6 +5,14 @@ export function clipboardWriteCommand(args: {
   text: string;
   message?: string;
 }): void {
+  // Fallback to displaying the target onto the information box,
+  // because access to the clipboard will be from the context
+  // of the server when ssh'ing.
+  if (process.env.SSH_CLIENT) {
+    vscode.window.showInformationMessage(args.text);
+    return;
+  }
+
   clipboardy.writeSync(args.text);
 
   const message = args.message || `Copied onto the clipboard: '${args.text}`;


### PR DESCRIPTION
There's a clipboard icon on top on BUILD rules that copies the target onto the clipboard for convenience. This however doesn't work when using remote development (i.e. ssh) with vscode, since the context is that of the server instead of the client. As a fallback, open an informational pop up with the target instead when using remote development.

Before:
<img width="502" alt="Screenshot 2022-08-09 at 09 31 20" src="https://user-images.githubusercontent.com/15216823/183603287-accdb4c9-a13c-47af-b1b0-515095987682.png">

After:
<img width="485" alt="Screenshot 2022-08-09 at 09 32 04" src="https://user-images.githubusercontent.com/15216823/183603317-c002439a-b807-4155-9bf7-f53ac7e01134.png">
